### PR TITLE
Fixed public paths using hardcoded resource name

### DIFF
--- a/server/express.js
+++ b/server/express.js
@@ -6,9 +6,9 @@ import cors from 'cors';
 import path from 'path';
 import { isWhitelistOn, isWhitelisted } from './bot';
 
-const htmlPath = path.join(alt.getResourcePath('altv-discord-auth'), 'server/html');
-const stylesPath = path.join(alt.getResourcePath('altv-discord-auth'), 'server/html/styles');
-const jsPaths = path.join(alt.getResourcePath('altv-discord-auth'), 'server/html/js');
+const htmlPath = path.join(alt.getResourcePath(alt.resourceName), 'server/html');
+const stylesPath = path.join(alt.getResourcePath(alt.resourceName), 'server/html/styles');
+const jsPaths = path.join(alt.getResourcePath(alt.resourceName), 'server/html/js');
 const app = express();
 
 app.use(cors());


### PR DESCRIPTION
Some people tried to use this resource by copying the files into their own resource instead of using it as an seperate resource, this caused the public path to be wrong.
This also allows the user to change the resource name without having to change it in the code every time.